### PR TITLE
build: add -cni suffix for image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ TARGETS := multus
 #   $[REGISTRY]/$[IMAGE_PREFIX]$[TARGET]$[IMAGE_SUFFIX]:$[VERSION]
 # $[REGISTRY] is an item from $[REGISTRIES], $[TARGET] is an item from $[TARGETS].
 IMAGE_PREFIX ?= $(strip )
-IMAGE_SUFFIX ?= $(strip )
+IMAGE_SUFFIX ?= $(strip -cni)
 
 # Container registry for base images.
 BASE_REGISTRY ?= cargo.caicloud.xyz/library


### PR DESCRIPTION
优化 build，修改 Makefile，增加镜像的 suffix “-cni“，避免 make container 时生成的镜像 name 错误，